### PR TITLE
Added support for philips.light.candle2

### DIFF
--- a/lib/devices/philips-light-bulb.js
+++ b/lib/devices/philips-light-bulb.js
@@ -15,7 +15,7 @@ module.exports = class BallLamp extends LightBulb
 	.with(MiioApi, Power, Dimmable, Colorable, ColorTemperature)
 {
 	static get type() {
-		return 'miio:philiphs-ball-lamp';
+		return 'miio:philips-light';
 	}
 
 	constructor(options) {
@@ -69,5 +69,4 @@ module.exports = class BallLamp extends LightBulb
 			refresh: [ 'color']
 		}).then(MiioApi.checkOk);
 	}
-
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -17,6 +17,8 @@ const Humidifier = require('./devices/humidifier');
 const YeelightColor = require('./devices/yeelight.color');
 const YeelightMono = require('./devices/yeelight.mono');
 
+const PhilipsLightBulb = require('./devices/philips-light-bulb');
+
 module.exports = {
 	'zhimi.airmonitor.v1': AirMonitor,
 
@@ -29,13 +31,13 @@ module.exports = {
 	// Air Purifier 2
 	'zhimi.airpurifier.m1': AirPurifier,
 	'zhimi.airpurifier.m2': AirPurifier,
-  
+
 	// Air Purifier 2S
 	'zhimi.airpurifier.ma2': AirPurifier,
-  'zhimi.airpurifier.mc1': AirPurifier,
+	'zhimi.airpurifier.mc1': AirPurifier,
 
 	'zhimi.humidifier.v1': Humidifier,
-  'zhimi.humidifier.ca1': Humidifier,
+	'zhimi.humidifier.ca1': Humidifier,
 
 	'chuangmi.plug.m1': PowerPlug,
 	'chuangmi.plug.v1': require('./devices/chuangmi.plug.v1'),
@@ -59,6 +61,6 @@ module.exports = {
 	'yeelink.light.strip1': YeelightColor,
 
 	'philips.light.sread1': require('./devices/eyecare-lamp2'),
-	'philips.light.bulb': require('./devices/philips-light-bulb')
-
+	'philips.light.bulb': PhilipsLightBulb,
+	'philips.light.candle2': PhilipsLightBulb
 };


### PR DESCRIPTION
The Philips Zhirui bulbs and candles are almost identical. Both support the same commands and have the same color range (3000K-5700K). They also support more command than described in this miio API (delay_off and apply_fixed_scene). I might add these commands if those would be needed by someone.

Here I have an example of the full protocol of both lights:
[protocol.txt](https://github.com/jghaanstra/miio/files/2609056/protocol.txt)
