### PR TITLE
Disable humidifier2

### DIFF
--- a/lib/models.js
+++ b/lib/models.js
@@ -13,7 +13,7 @@ const PowerPlug = require('./devices/power-plug');
 const PowerStrip = require('./devices/power-strip');
 
 const Humidifier = require('./devices/humidifier');
-const Humidifier2 = require('./devices/humidifier2');
+//const Humidifier2 = require('./devices/humidifier2');
 
 const YeelightColor = require('./devices/yeelight.color');
 const YeelightMono = require('./devices/yeelight.mono');
@@ -38,7 +38,7 @@ module.exports = {
 	'zhimi.airpurifier.mc1': AirPurifier,
 
 	'zhimi.humidifier.v1': Humidifier,
-	'zhimi.humidifier.ca1': Humidifier2,
+	//'zhimi.humidifier.ca1': Humidifier2,
 
 	'chuangmi.plug.m1': PowerPlug,
 	'chuangmi.plug.v1': require('./devices/chuangmi.plug.v1'),


### PR DESCRIPTION
`Depth` property seems not implemented in `abstarct-things`. See https://github.com/tinkerhub/abstract-things/pull/3

Current master crashes with:
```
Error: Trying to apply non-existent mixin
    at mix (/opt/iobroker/node_modules/foibles/index.js:33:10)
    at Function.type.with (/opt/iobroker/node_modules/foibles/index.js:55:10)
    at Object.<anonymous> (/opt/iobroker/node_modules/miio/lib/devices/humidifier2.js:19:7)
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
    at Module.require (module.js:597:17)
    at require (internal/module.js:11:18)
```

Of course this "fix" is lame by just disabling humifier2 but unfortunately you do not have the Github Issues enabled.

In any case: Many thanks for keeping this essential lib alive! Really appreciated 👍 